### PR TITLE
Change shebang for ./script/src to improve portability

### DIFF
--- a/script/server
+++ b/script/server
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 # script/server: Launch the application and any extra required processes
 #                locally.


### PR DESCRIPTION
One line change to the shebang for `./script/src` to increase portability.

Fixes #86 