### PR TITLE
Update chime container version in Deployment manifest

### DIFF
--- a/k8s/app.yaml
+++ b/k8s/app.yaml
@@ -25,7 +25,7 @@ spec:
         app: chime
     spec:
       containers:
-      - image: docker.pkg.github.com/codeforphilly/chime/penn-chime:0.3.1
+      - image: docker.pkg.github.com/codeforphilly/chime/penn-chime:0.4.0
         name: chime
         ports:
         - containerPort: 8000


### PR DESCRIPTION
Update chime container version in Deployment manifest

0.4.0 is the latest validated version as of this commit