### PR TITLE
add sim_sir_df

### DIFF
--- a/penn_chime/models.py
+++ b/penn_chime/models.py
@@ -28,15 +28,15 @@ def sir(
 def gen_sir(
     s: float, i: float, r: float,
     beta: float, gamma: float, n_days: int, beta_decay: float = 0.0
-) -> Generator:
+) -> Generator[Tuple[float, float, float], None, None]:
     """Simulate SIR model forward in time yielding tuples."""
-    s, i, r, beta_decay = (float(v) for v in (s, i, r, beta_decay))
+    s, i, r = (float(v) for v in (s, i, r))
     n = s + i + r
+    f = 1.0 - beta_decay  # okay even if beta_decay is 0.0
     for _ in range(n_days + 1):
         yield s, i, r
         s, i, r = sir(s, i, r, beta, gamma, n)
-        # okay even if beta_decay is 0.0
-        beta = beta * (1.0 - beta_decay)
+        beta *= f
 
 
 @st.cache
@@ -45,13 +45,13 @@ def sim_sir(
     beta: float, gamma: float, n_days: int, beta_decay: float = 0.0
 ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
     """Simulate the SIR model forward in time."""
-    s, i, r, beta_decay = (float(v) for v in (s, i, r, beta_decay))
+    s, i, r = (float(v) for v in (s, i, r))
     n = s + i + r
+    f = 1.0 - beta_decay  # okay even if beta_decay is 0.0
     s_v, i_v, r_v = [s], [i], [r]
     for day in range(n_days):
         s, i, r = sir(s, i, r, beta, gamma, n)
-        # okay even if beta_decay is 0.0
-        beta = beta * (1.0 - beta_decay)
+        beta *= f
         s_v.append(s)
         i_v.append(i)
         r_v.append(r)

--- a/test_app.py
+++ b/test_app.py
@@ -5,7 +5,7 @@ from app import (S_default, known_infections, known_cases, current_hosp, doublin
                  hosp_rate, icu_rate, vent_rate, hosp_los, icu_los, vent_los, market_share, S, initial_infections,
                  detection_prob, hospitalization_rates, I, R, beta, gamma, n_days, beta_decay,
                  projection_admits, alt)
-from penn_chime.models import sir, sim_sir
+from penn_chime.models import sir, sim_sir, sim_sir_df
 from penn_chime.presentation import display_header, new_admissions_chart
 
 
@@ -70,12 +70,11 @@ def test_header_fail():
 
 # Test the math
 
-
 def test_sir():
     """
     Someone who is good at testing, help
     """
-    assert sir((100, 1, 0), 0.2, 0.5, 1) == (
+    assert sir(100, 1, 0, 0.2, 0.5, 1) == (
         0.7920792079207921,
         0.20297029702970298,
         0.0049504950495049506,
@@ -88,11 +87,26 @@ def test_sim_sir():
     """
     s, i, r = sim_sir(S, I, R, beta, gamma, n_days, beta_decay=beta_decay)
     assert round(s[0], 0) == 4119405
-    assert round(s[-1], 2) == 3421436.31
     assert round(i[0], 2) == 533.33
+    assert round(r[0], 0) == 0.0
+    assert round(s[-1], 2) == 3421436.31
     assert round(i[-1], 2) == 418157.62
-    assert round(r[0], 0) == 0
     assert round(r[-1], 2) == 280344.40
+
+
+def test_sim_sir_df():
+    """
+    Rounding to move fast past decimal place issues
+    """
+    df = sim_sir_df(S, I, R, beta, gamma, n_days, beta_decay=beta_decay)
+    first = df.iloc[0]
+    last = df.iloc[-1]
+    assert round(first[0], 0) == 4119405
+    assert round(first[1], 2) == 533.33
+    assert round(first[2], 0) == 0.0
+    assert round(last[0], 2) == 3421436.31
+    assert round(last[1], 2) == 418157.62
+    assert round(last[2], 2) == 280344.40
 
 
 def test_initial_conditions():


### PR DESCRIPTION
Add `sim_sir_df(...) -> pd.DataFrame`
Eliminate multiple implicit int casts to float in `sir(...)` comparisons.
Eliminate tuple unpacking of `y` in `sir(...)`.
Add test for `sim_sir_df(...)`.
Add type annotations.
Allow variadic number of rates to be passed to get_hospitalizations2.

Refers to #108 