### PR TITLE
Add date formatting to x-axis

### DIFF
--- a/src/penn_chime/charts.py
+++ b/src/penn_chime/charts.py
@@ -7,6 +7,7 @@ import numpy as np  # type: ignore
 
 from .parameters import Parameters
 from .utils import add_date_column
+from .presentation import DATE_FORMAT
 
 
 def new_admissions_chart(
@@ -26,7 +27,7 @@ def new_admissions_chart(
     tooltip_dict = {False: "day", True: "date:T"}
     if as_date:
         projection_admits = add_date_column(projection_admits)
-        x_kwargs = {"shorthand": "date:T", "title": "Date"}
+        x_kwargs = {"shorthand": "date:T", "title": "Date", "axis": alt.Axis(format=(DATE_FORMAT))}
     else:
         x_kwargs = {"shorthand": "day", "title": "Days from today"}
 
@@ -58,7 +59,7 @@ def admitted_patients_chart(
     as_date = parameters.as_date
     if as_date:
         census = add_date_column(census)
-        x_kwargs = {"shorthand": "date:T", "title": "Date"}
+        x_kwargs = {"shorthand": "date:T", "title": "Date", "axis": alt.Axis(format=(DATE_FORMAT))}
         idx = "date:T"
     else:
         x_kwargs = {"shorthand": "day", "title": "Days from today"}
@@ -101,7 +102,7 @@ def additional_projections_chart(
 
     if as_date:
         dat = add_date_column(dat)
-        x_kwargs = {"shorthand": "date:T", "title": "Date"}
+        x_kwargs = {"shorthand": "date:T", "title": "Date", "axis": alt.Axis(format=(DATE_FORMAT))}
     else:
         x_kwargs = {"shorthand": "day", "title": "Days from today"}
 


### PR DESCRIPTION
This PR adds date formatting to the x-axis. Previously, the charts were using the default date formatting, this forces the x-axis labels to be in `%b, %d` format, i.e. `Mar, 25` for March 25th.

Closes https://github.com/CodeForPhilly/chime/issues/213

Question for @quinn-dougherty  or anyone else, this pulls in the `DATE_FORMAT` from presentation.py, should I add date format to the ~`Presentation`~ `Parameters` model?
