### PR TITLE
Time advanced initialization

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -53,6 +53,13 @@ def parse_args():
             "Currently Hospitalized COVID-19 Patients (>= 0)",
         ),
         (
+            "--new-admissions",
+            int,
+            0,
+            None,
+            "New admissions in most recent 24-hour period (>= 0)",
+        ),
+        (
             "--doubling-time",
             float,
             0.0,
@@ -105,6 +112,7 @@ def main():
 
     p = Parameters(
         current_hospitalized=a.current_hospitalized,
+        new_admissions=a.new_admissions,
         doubling_time=a.doubling_time,
         known_infected=a.known_infected,
         market_share=a.market_share,

--- a/src/penn_chime/defaults.py
+++ b/src/penn_chime/defaults.py
@@ -23,6 +23,7 @@ class Constants:
         self,
         *,
         current_hospitalized: int,
+        new_admissions: int,
         doubling_time: int,
         known_infected: int,
         relative_contact_rate: int,
@@ -40,6 +41,7 @@ class Constants:
     ):
         self.region = region
         self.current_hospitalized = current_hospitalized
+        self.new_admissions = new_admissions
         self.known_infected = known_infected
         self.doubling_time = doubling_time
         self.relative_contact_rate = relative_contact_rate

--- a/src/penn_chime/models.py
+++ b/src/penn_chime/models.py
@@ -38,8 +38,17 @@ class SimSirModel:
 
         self.gamma = gamma = 1.0 / p.recovery_days
 
-        # Contact rate, beta
+        # from the timestep function sir(), we derive:
+        # new_infections = beta * s * i
+        # new_admissions = new_infections * market_share * hospitalized.rate
+        # Substitute and rearrange to obtain:
         self.beta = beta = (
+            p.new_admissions
+            / ( susceptible * infected*p.market_share * p.hospitalized.rate )
+        )
+
+        # Contact rate, beta
+        self.beta_old = (
             (intrinsic_growth_rate + gamma)
             / p.susceptible
             * (1.0 - p.relative_contact_rate)
@@ -93,8 +102,9 @@ def sir(
     s: float, i: float, r: float, beta: float, gamma: float, n: float
 ) -> Tuple[float, float, float]:
     """The SIR model, one time step."""
-    s_n = (-beta * s * i) + s
-    i_n = (beta * s * i - gamma * i) + i
+    new_infections = beta * s * i
+    s_n = (-new_infections) + s
+    i_n = (new_infections - gamma * i) + i
     r_n = gamma * i + r
     if s_n < 0.0:
         s_n = 0.0

--- a/src/penn_chime/parameters.py
+++ b/src/penn_chime/parameters.py
@@ -14,6 +14,7 @@ class Parameters:
         self,
         *,
         current_hospitalized: int,
+        new_admissions: int,
         doubling_time: float,
         known_infected: int,
         relative_contact_rate: float,
@@ -30,6 +31,7 @@ class Parameters:
         recovery_days: int = 14,
     ):
         self.current_hospitalized = current_hospitalized
+        self.new_admissions = new_admissions
         self.doubling_time = doubling_time
         self.known_infected = known_infected
         self.relative_contact_rate = relative_contact_rate

--- a/src/penn_chime/presentation.py
+++ b/src/penn_chime/presentation.py
@@ -110,6 +110,14 @@ def display_sidebar(st, d: Constants) -> Parameters:
         format="%i",
     )
 
+    new_admissions = st.sidebar.number_input(
+        "New admissions in most recent 24-hour period (>= 0)",
+        min_value=1,
+        value=d.new_admissions,
+        step=1,
+        format="%i",
+    )
+
     doubling_time = st.sidebar.number_input(
         "Doubling time before social distancing (days)",
         min_value=0,

--- a/src/penn_chime/settings.py
+++ b/src/penn_chime/settings.py
@@ -18,6 +18,7 @@ DEFAULTS = Constants(
         philly=philly,
     ),
     current_hospitalized=14,
+    new_admissions=4,
     doubling_time=4,
     known_infected=510,
     n_days=60,

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -16,6 +16,7 @@ from src.penn_chime.defaults import RateLos
 
 PARAM = Parameters(
     current_hospitalized=100,
+    new_admissions=18,
     doubling_time=6.0,
     known_infected=5000,
     market_share=0.05,


### PR DESCRIPTION
Allow initialization of the model's infection rate based on a recent observation of new patients and the existing patient population. Still has to make an assumption on how many infected have to be hospitalized, but doesn't require any broad assumptions about big-picture trends, like doubling time does.