### PR TITLE
Fix text in CLI help

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -92,7 +92,7 @@ def parse_args():
             "Social Distancing Reduction Rate: 0.0 - 1.0",
         ),
         ("--susceptible", int, 1, None, "Regional Population >= 1"),
-        ("--ventilated-los", int, 0, None, "Hospitalized Length of Stay (days)"),
+        ("--ventilated-los", int, 0, None, "Ventilated Length of Stay (days)"),
         ("--ventilated-rate", float, 0.0, 1.0, "Ventilated Rate: 0.0 - 1.0"),
     ):
         parser.add_argument(arg, type=validator(cast, min_value, max_value))


### PR DESCRIPTION
The help for the parameter `--ventilated-los` is `Hospitalized Length of Stay (days)`, which is a repeat of an another parameter descriptions and I think should say `Ventilated Length of Stay (days)`. If that's not the correct replacement text but it is in fact incorrect on master, let me know and I'll update the PR.