### PR TITLE
Slider bar code cleanup

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -55,8 +55,11 @@ if st.checkbox("Show Projected Admissions in tabular form"):
         draw_projected_admissions_table(st, m.admits_df, p.labels, 1, as_date=p.as_date)
     else:
         admissions_day_range = st.slider(
-            'Interval of Days for Projected Admissions',
-            1, 10, 7
+            label="Interval of Days",
+            key="admissions_day_range_slider",
+            min_value=1,
+            max_value=10,
+            value=7 
         )
         draw_projected_admissions_table(st, m.admits_df, p.labels, admissions_day_range, as_date=p.as_date)
     build_download_link(st,
@@ -79,8 +82,11 @@ if st.checkbox("Show Projected Census in tabular form"):
         draw_census_table(st, m.census_df, p.labels, 1, as_date=p.as_date)
     else:
         census_day_range = st.slider(
-            'Interval of Days for Projected Census',
-            1, 10, 7
+            label='Interval of Days',
+            key="census_day_range_slider",
+            min_value=1,
+            max_value=10,
+            value=7 
         )
         draw_census_table(st, m.census_df, p.labels, census_day_range, as_date=p.as_date)
     build_download_link(st,


### PR DESCRIPTION
Added a unique key parameter to the Projected Admissions and Projected Census sliders so they can display the same label. Also replaced shorthand with min_value, max_value, and value parameters.

There is a current issue with the slider where it keeps reverting to the default value. Steps to reproduce: move the slider to a different value, click the checkbox to Show Daily Counts, and then uncheck the box. The slider will revert to its default value. Some more information in the below link. Any suggestions for a fix appreciated.

https://github.com/streamlit/streamlit/issues/218