### PR TITLE
[dash] Add scripts and config files to use docker-compose workflow

### DIFF
--- a/Dockerfile.dash
+++ b/Dockerfile.dash
@@ -2,6 +2,9 @@ FROM python:3.7.7-slim-buster
 
 WORKDIR /code 
 
+ARG PORT
+ENV PORT $PORT
+
 COPY requirements.txt requirements.txt
 RUN pip install -q -r requirements.txt
 

--- a/docker-compose-dash.yml
+++ b/docker-compose-dash.yml
@@ -1,0 +1,12 @@
+version: '3.1'
+
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile.dash
+      args:
+        - PORT=${PORT}
+    restart: always
+    ports:
+      - "${PORT}:8000"

--- a/script/server-dash
+++ b/script/server-dash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# script/server: Launch the application and any extra required processes
+#                locally.
+
+set -e
+cd "$(dirname "$0")/.."
+
+
+script/bootstrap
+
+if [ ! -f ".env" ]; then
+    echo
+    echo "==> Initializing .env…"
+    cp .env.example .env
+fi
+
+echo
+echo "==> Loading .env…"
+set -o allexport; source .env; set +o allexport
+
+echo
+echo "==> Starting containers with docker-compose…"
+docker-compose -f docker-compose-dash.yml up -d --build
+
+echo
+echo "==> App is now ready to go!"
+echo "    *Open http://localhost:${PORT}"
+echo

--- a/src/dash_app.py
+++ b/src/dash_app.py
@@ -42,4 +42,3 @@ def callback(*args):  # pylint: disable=W0612
 if __name__ == "__main__":
 #    main()
     app.run_server(host='0.0.0.0')
-


### PR DESCRIPTION
This PR adds scripts and config files to support a docker-compose workflow for the dash app. Running `./script/server-dash` will start up the dash app.