### PR TITLE
Fix to Streamlit config copy path in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.7.7-slim-buster
 RUN mkdir /app
 WORKDIR /app
-COPY .streamlit ~/
+COPY .streamlit .streamlit
 COPY README.md .
 COPY setup.py .
 COPY settings.cfg .


### PR DESCRIPTION
Fix to Dockerfile to ensure Streamlit config files are copied to a location expected by Streamlit

Fixes #280