### PR TITLE
Updates to number input step, min val, and types

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
 FROM python:3.7.7-slim-buster
 RUN mkdir /app
 WORKDIR /app
-COPY .streamlit .streamlit
 COPY README.md .
 COPY setup.py .
+# Creating an empty src dir is a (hopefully) temporary hack to improve layer caching and speed up image builds
+# todo fix once the Pipfile, setup.py, requirements.txt, pyprojec.toml build/dist story is figured out
+RUN mkdir src && pip install -q .
+COPY .streamlit .streamlit
 COPY settings.cfg .
 COPY src src
-RUN pip install -q .
 
 CMD ["streamlit", "run", "src/app.py"]

--- a/e2e/cypress/integration/tests/actions.spec.js
+++ b/e2e/cypress/integration/tests/actions.spec.js
@@ -11,6 +11,6 @@ context('Actions', () => {
     // This gets the "first" input from the sidebar. From clicking step up,
     // the Regional Population should increase from default 4119405 to 4219405.
     cy.get('input.st-al')
-      .should('has.value', '4219405')
+      .should('has.value', '4119406')
   })
 });

--- a/src/penn_chime/defaults.py
+++ b/src/penn_chime/defaults.py
@@ -20,9 +20,9 @@ class Constants:
         self,
         *,
         current_hospitalized: int,
-        doubling_time: int,
+        doubling_time: float,
         known_infected: int,
-        relative_contact_rate: int,
+        relative_contact_rate: float,
         region: Regions,
 
         hospitalized: RateLos,

--- a/src/penn_chime/presentation.py
+++ b/src/penn_chime/presentation.py
@@ -290,7 +290,7 @@ def display_sidebar(st, d: Constants) -> Parameters:
     return Parameters(
         as_date=as_date,
         current_hospitalized=current_hospitalized,
-        market_share=market_share,
+        market_share=market_share / 100.0,
         known_infected=known_infected,
         doubling_time=doubling_time,
 

--- a/src/penn_chime/presentation.py
+++ b/src/penn_chime/presentation.py
@@ -1,8 +1,5 @@
 """effectful functions for streamlit io"""
 
-from typing import Optional
-
-import altair as alt  # type: ignore
 import numpy as np  # type: ignore
 import pandas as pd  # type: ignore
 
@@ -12,6 +9,9 @@ from .parameters import Parameters
 
 DATE_FORMAT = "%b, %d"  # see https://strftime.org
 DOCS_URL = "https://code-for-philly.gitbook.io/chime"
+
+FLOAT_INPUT_MIN = 0.001
+FLOAT_INPUT_STEP = FLOAT_INPUT_MIN
 
 hide_menu_style = """
         <style>
@@ -158,33 +158,33 @@ def display_sidebar(st, d: Constants) -> Parameters:
         "Number of days to project",
         min_value=30,
         value=d.n_days,
-        step=10,
+        step=1,
         format="%i",
     )
     doubling_time_input = NumberInputWrapper(
         st_obj,
         "Doubling time before social distancing (days)",
-        min_value=0,
+        min_value=FLOAT_INPUT_MIN,
         value=d.doubling_time,
-        step=1,
-        format="%i",
+        step=FLOAT_INPUT_STEP,
+        format="%f",
     )
     relative_contact_rate_input = NumberInputWrapper(
         st_obj,
         "Social distancing (% reduction in social contact)",
-        min_value=0,
-        max_value=100,
-        value=int(d.relative_contact_rate * 100),
-        step=5,
-        format="%i",
+        min_value=0.0,
+        max_value=100.0,
+        value=d.relative_contact_rate * 100.0,
+        step=FLOAT_INPUT_STEP,
+        format="%f",
     )
     hospitalized_rate_input = NumberInputWrapper(
         st_obj,
         "Hospitalization %(total infections)",
-        min_value=0.001,
+        min_value=0.0,
         max_value=100.0,
         value=d.hospitalized.rate * 100,
-        step=1.0,
+        step=FLOAT_INPUT_STEP,
         format="%f",
     )
     icu_rate_input = NumberInputWrapper(
@@ -193,7 +193,7 @@ def display_sidebar(st, d: Constants) -> Parameters:
         min_value=0.0,
         max_value=100.0,
         value=d.icu.rate * 100,
-        step=1.0,
+        step=FLOAT_INPUT_STEP,
         format="%f",
     )
     ventilated_rate_input = NumberInputWrapper(
@@ -202,7 +202,7 @@ def display_sidebar(st, d: Constants) -> Parameters:
         min_value=0.0,
         max_value=100.0,
         value=d.ventilated.rate * 100,
-        step=1.0,
+        step=FLOAT_INPUT_STEP,
         format="%f",
     )
     hospitalized_los_input = NumberInputWrapper(
@@ -232,10 +232,10 @@ def display_sidebar(st, d: Constants) -> Parameters:
     market_share_input = NumberInputWrapper(
         st_obj,
         "Hospital Market Share (%)",
-        min_value=0.001,
+        min_value=FLOAT_INPUT_MIN,
         max_value=100.0,
         value=d.market_share * 100,
-        step=1.0,
+        step=FLOAT_INPUT_STEP,
         format="%f",
     )
     population_input = NumberInputWrapper(
@@ -243,7 +243,7 @@ def display_sidebar(st, d: Constants) -> Parameters:
         "Regional Population",
         min_value=1,
         value=d.region.population,
-        step=100000,
+        step=1,
         format="%i",
     )
     known_infected_input = NumberInputWrapper(
@@ -251,13 +251,12 @@ def display_sidebar(st, d: Constants) -> Parameters:
         "Currently Known Regional Infections (only used to compute detection rate - does not change projections)",
         min_value=0,
         value=d.known_infected,
-        step=10,
+        step=1,
         format="%i",
     )
     as_date_input = CheckboxWrapper(st_obj, "Present result as dates instead of days", value=False)
     max_y_axis_set_input = CheckboxWrapper(st_obj, "Set the Y-axis on graphs to a static value")
     max_y_axis_input = NumberInputWrapper(st_obj, "Y-axis static value", value=500, format="%i", step=25)
-
 
     # Build in desired order
     st.sidebar.markdown("### Regional Parameters [ℹ]({docs_url}/what-is-chime/parameters)".format(docs_url=DOCS_URL))
@@ -300,9 +299,9 @@ def display_sidebar(st, d: Constants) -> Parameters:
         relative_contact_rate=relative_contact_rate / 100.0,
         population=population,
 
-        hospitalized=RateLos(hospitalized_rate/ 100.0, hospitalized_los),
-        icu=RateLos(icu_rate/ 100.0, icu_los),
-        ventilated=RateLos(ventilated_rate/ 100.0, ventilated_los),
+        hospitalized=RateLos(hospitalized_rate / 100.0, hospitalized_los),
+        icu=RateLos(icu_rate / 100.0, icu_los),
+        ventilated=RateLos(ventilated_rate / 100.0, ventilated_los),
     )
 
 

--- a/src/penn_chime/settings.py
+++ b/src/penn_chime/settings.py
@@ -18,7 +18,7 @@ DEFAULTS = Constants(
         philly=philly,
     ),
     current_hospitalized=14,
-    doubling_time=4,
+    doubling_time=4.0,
     known_infected=510,
     n_days=60,
     market_share=0.15,


### PR DESCRIPTION
All changes in  `./src/penn_chime/`
**Fixes for issue 269**
* `presentation.py` Updated min value and step for most number inputs.
* `presentation.py` Updated format for float inputs to display as float instead of as int.
* `defaults.py` Change Constants type for doubling_time and relative_contact_rate from int to float
* `settings.py`Change default doubling_time from int to float

**Cleanup**
* Removed unused imports in `presentation.py`

Fixes #269 