### PR TITLE
[Dash] Present results as dates & show tables with data causes KeyError

### DIFF
--- a/src/chime_dash/app/utils/templates.py
+++ b/src/chime_dash/app/utils/templates.py
@@ -74,6 +74,7 @@ def df_to_html_table(
     """Converts pandas data frame to html table
     """
     index_name = dataframe.index.name
+    index_name = "index" if index_name is None else index_name
     tmp = dataframe.reset_index()
     tmp = tmp[mod(tmp.index, n_mod) == 0].copy()
     tmp = tmp.set_index(index_name)


### PR DESCRIPTION
I encountered that turning on the switches `Present results as dates` and `Show tables with data` causes a `KeyError` in `visualizations.py`. When trying to create a df with dates, the index column did not have a name. This is accounted for with this fix.