### PR TITLE
Remove confirmed cases & detection prob

### DIFF
--- a/src/penn_chime/models.py
+++ b/src/penn_chime/models.py
@@ -59,10 +59,6 @@ class SimSirModel:
 
         susceptible = p.population - infected
 
-        detection_probability = (
-            p.known_infected / infected if infected > EPSILON else None
-        )
-
         intrinsic_growth_rate = get_growth_rate(p.doubling_time)
 
         gamma = 1.0 / p.infectious_days
@@ -85,8 +81,6 @@ class SimSirModel:
         self.susceptible = susceptible
         self.infected = infected
         self.recovered = p.recovered
-
-        self.detection_probability = detection_probability
 
         self.beta = beta
         self.gamma = gamma

--- a/src/penn_chime/parameters.py
+++ b/src/penn_chime/parameters.py
@@ -34,10 +34,8 @@ class Parameters:
         current_hospitalized: int,
         hospitalized: RateLos,
         icu: RateLos,
-        known_infected: int,
         relative_contact_rate: float,
         ventilated: RateLos,
-
         current_date: date = date.today(),
         date_first_hospitalized: Optional[date] = None,
         doubling_time: Optional[float] = None,
@@ -51,7 +49,6 @@ class Parameters:
     ):
 
         self.current_hospitalized = current_hospitalized
-        self.known_infected = known_infected
         self.relative_contact_rate = relative_contact_rate
 
         self.hospitalized = hospitalized

--- a/src/penn_chime/settings.py
+++ b/src/penn_chime/settings.py
@@ -18,7 +18,6 @@ DEFAULTS = Parameters(
     hospitalized=RateLos(0.025, 7),
     icu=RateLos(0.0075, 9),
     infectious_days=14,
-    known_infected=510,
     market_share=0.15,
     n_days=75,
     relative_contact_rate=0.3,


### PR DESCRIPTION
These are irrelevant to the calculations and only cause user confusion.

"Currently Known Regional Infections" does not impact the projections since we estimate total number of infections using the hospitalized cases. This leads to user confusion. The detection probability by extension is also superfluous. The PR removes both.