### PR TITLE
Add disposition type

### DIFF
--- a/src/penn_chime/cli.py
+++ b/src/penn_chime/cli.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from pandas import DataFrame
 
 from .constants import CHANGE_DATE
-from .parameters import Parameters, RateDays
+from .parameters import Parameters, Disposition
 from .models import SimSirModel as Model
 
 
@@ -129,9 +129,9 @@ def main():
         relative_contact_rate=a.relative_contact_rate,
         population=a.population,
 
-        hospitalized=RateDays(a.hospitalized_rate, a.hospitalized_days),
-        icu=RateDays(a.icu_rate, a.icu_days),
-        ventilated=RateDays(a.ventilated_rate, a.ventilated_days),
+        hospitalized=Disposition(a.hospitalized_rate, a.hospitalized_days),
+        icu=Disposition(a.icu_rate, a.icu_days),
+        ventilated=Disposition(a.ventilated_rate, a.ventilated_days),
     )
 
     m = Model(p)

--- a/src/penn_chime/parameters.py
+++ b/src/penn_chime/parameters.py
@@ -11,7 +11,7 @@ from typing import Optional
 
 # (0.02, 7) is 2%, 7 days
 # be sure to multiply by 100 when using as a default to the percent widgets!
-RateDays = namedtuple("RateDays", ("rate", "days"))
+Disposition = namedtuple("Disposition", ("rate", "days"))
 
 
 class Regions:
@@ -32,10 +32,10 @@ class Parameters:
         self,
         *,
         current_hospitalized: int,
-        hospitalized: RateDays,
-        icu: RateDays,
+        hospitalized: Disposition,
+        icu: Disposition,
         relative_contact_rate: float,
-        ventilated: RateDays,
+        ventilated: Disposition,
         current_date: date = date.today(),
         date_first_hospitalized: Optional[date] = None,
         doubling_time: Optional[float] = None,

--- a/src/penn_chime/parameters.py
+++ b/src/penn_chime/parameters.py
@@ -9,8 +9,25 @@ from datetime import date
 from typing import Optional
 
 
-# (0.02, 7) is 2%, 7 days
-# be sure to multiply by 100 when using as a default to the percent widgets!
+# Parameters for each disposition (hospitalized, icu, ventilated)
+#   The rate of disposition within the population of infected
+#   The average number days a patient has such disposition
+
+# Hospitalized:
+#   2.5 percent of the infected population are hospitalized: hospitalized.rate is 0.025
+#   Average hospital length of stay is 7 days: hospitalized.days = 7
+
+# ICU:
+#   0.75 percent of the infected population are in the ICU: icu.rate is 0.0075
+#   Average number of days in an ICU is 9 days: icu.days = 9
+
+# Ventilated:
+#   0.5 percent of the infected population are on a ventilator: ventilated.rate is 0.005
+#   Average number of days on a ventilator: ventilated.days = 10
+
+# Be sure to multiply by 100 when using the parameter as a default to a percent widget!
+
+
 Disposition = namedtuple("Disposition", ("rate", "days"))
 
 

--- a/src/penn_chime/presentation.py
+++ b/src/penn_chime/presentation.py
@@ -16,7 +16,7 @@ from .constants import (
 )
 
 from .utils import dataframe_to_base64
-from .parameters import Parameters, RateDays
+from .parameters import Parameters, Disposition
 from .models import SimSirModel as Model
 
 hide_menu_style = """
@@ -285,10 +285,10 @@ def display_sidebar(st, d: Parameters) -> Parameters:
 
     return Parameters(
         current_hospitalized=current_hospitalized,
-        hospitalized=RateDays(hospitalized_rate, hospitalized_days),
-        icu=RateDays(icu_rate, icu_days),
+        hospitalized=Disposition(hospitalized_rate, hospitalized_days),
+        icu=Disposition(icu_rate, icu_days),
         relative_contact_rate=relative_contact_rate,
-        ventilated=RateDays(ventilated_rate, ventilated_days),
+        ventilated=Disposition(ventilated_rate, ventilated_days),
 
         current_date=current_date,
         date_first_hospitalized=date_first_hospitalized,

--- a/src/penn_chime/settings.py
+++ b/src/penn_chime/settings.py
@@ -2,7 +2,7 @@
 
 from datetime import date
 
-from .parameters import Parameters, Regions, RateDays
+from .parameters import Parameters, Regions, Disposition
 
 DEFAULTS = Parameters(
     region=Regions(
@@ -15,11 +15,11 @@ DEFAULTS = Parameters(
     current_hospitalized=32,
     date_first_hospitalized=date(2020,3,7),
     doubling_time=4.0,
-    hospitalized=RateDays(0.025, 7),
-    icu=RateDays(0.0075, 9),
+    hospitalized=Disposition(0.025, 7),
+    icu=Disposition(0.0075, 9),
     infectious_days=14,
     market_share=0.15,
     n_days=60,
     relative_contact_rate=0.3,
-    ventilated=RateDays(0.005, 10),
+    ventilated=Disposition(0.005, 10),
 )

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -22,7 +22,7 @@ from src.penn_chime.models import (
 )
 from src.penn_chime.parameters import (
     Parameters,
-    RateDays,
+    Disposition,
     Regions,
 )
 from src.penn_chime.presentation import display_header
@@ -45,9 +45,9 @@ DEFAULTS = Parameters(
     n_days=60,
     market_share=0.15,
     relative_contact_rate=0.3,
-    hospitalized=RateDays(0.025, 7),
-    icu=RateDays(0.0075, 9),
-    ventilated=RateDays(0.005, 10),
+    hospitalized=Disposition(0.025, 7),
+    icu=Disposition(0.0075, 9),
+    ventilated=Disposition(0.005, 10),
 )
 
 PARAM = Parameters(
@@ -56,9 +56,9 @@ PARAM = Parameters(
     market_share=0.05,
     relative_contact_rate=0.15,
     population=500000,
-    hospitalized=RateDays(0.05, 7),
-    icu=RateDays(0.02, 9),
-    ventilated=RateDays(0.01, 10),
+    hospitalized=Disposition(0.05, 7),
+    icu=Disposition(0.02, 9),
+    ventilated=Disposition(0.01, 10),
     n_days=60,
 )
 
@@ -68,9 +68,9 @@ HALVING_PARAM = Parameters(
     market_share=0.05,
     relative_contact_rate=0.7,
     population=500000,
-    hospitalized=RateDays(0.05, 7),
-    icu=RateDays(0.02, 9),
-    ventilated=RateDays(0.01, 10),
+    hospitalized=Disposition(0.05, 7),
+    icu=Disposition(0.02, 9),
+    ventilated=Disposition(0.01, 10),
     n_days=60,
 )
 


### PR DESCRIPTION
Naming of RateDays tuple is causing confusion and would have to be changed when we add PPE parameters for each disposition of (hospitalized, icu, ventilated) or (as a rate of infected, average days in disposition, ppe per day).

Rename to Disposition

Closes #356 