### PR TITLE
Add timeout wait to Cypress

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -44,4 +44,6 @@ jobs:
       uses: cypress-io/github-action@v1.23.2
       with:
         working-directory: e2e
+        wait-on: 'http://localhost:8000'
+        wait-on-timeout: 300
 


### PR DESCRIPTION
This should tell Cypress to wait for the app to come up before timing out (300) -- This fixes #214 