### PR TITLE
Issue #239: Fixed off by one day error

### DIFF
--- a/src/penn_chime/models.py
+++ b/src/penn_chime/models.py
@@ -296,7 +296,7 @@ def build_dispositions_df(
 
 def build_admits_df(dispositions_df: pd.DataFrame) -> pd.DataFrame:
     """Build admits dataframe from dispositions."""
-    admits_df = dispositions_df.iloc[:-1, :] - dispositions_df.shift(1)
+    admits_df = dispositions_df.iloc[:, :] - dispositions_df.shift(1)
     admits_df.day = dispositions_df.day
     admits_df.date = dispositions_df.date
     return admits_df

--- a/src/penn_chime/presentation.py
+++ b/src/penn_chime/presentation.py
@@ -327,7 +327,7 @@ def display_sidebar(st, d: Parameters) -> Parameters:
             docs_url=DOCS_URL
         )
     )
-    n_days = n_days_input()
+    n_days = n_days_input() + 1 # Overcome zero index error with panda df
     max_y_axis_set = max_y_axis_set_input()
 
     max_y_axis = None

--- a/src/penn_chime/presentation.py
+++ b/src/penn_chime/presentation.py
@@ -327,7 +327,7 @@ def display_sidebar(st, d: Parameters) -> Parameters:
             docs_url=DOCS_URL
         )
     )
-    n_days = n_days_input() + 1 # Overcome zero index error with panda df
+    n_days = n_days_input()
     max_y_axis_set = max_y_axis_set_input()
 
     max_y_axis = None
@@ -472,7 +472,7 @@ def write_footer(st):
 
 
 def display_download_link(st, filename: str, df: pd.DataFrame):
-    csv = dataframe_to_base64(df[:-1]) # Overcome zero index error with panda df
+    csv = dataframe_to_base64(df)
     st.markdown(
         """
         <a download="{filename}" href="data:file/csv;base64,{csv}">Download {filename}</a>

--- a/src/penn_chime/presentation.py
+++ b/src/penn_chime/presentation.py
@@ -472,7 +472,7 @@ def write_footer(st):
 
 
 def display_download_link(st, filename: str, df: pd.DataFrame):
-    csv = dataframe_to_base64(df)
+    csv = dataframe_to_base64(df[:-1]) # Overcome zero index error with panda df
     st.markdown(
         """
         <a download="{filename}" href="data:file/csv;base64,{csv}">Download {filename}</a>


### PR DESCRIPTION
The graph displays one day less than entered. Here is how the graph looks with the incorrect index

![Screenshot (3)_LI](https://user-images.githubusercontent.com/61572112/78084076-4729fc80-7385-11ea-8ac3-9231aa0ee29f.jpg)

The graph ends with July 8th, which is 99 days from today (3/31/2020). When removing the incorrect index, the graph extends to July 9th, 100 days from today (3/31/2020).

![Screenshot (4)_LI](https://user-images.githubusercontent.com/61572112/78084308-c9b2bc00-7385-11ea-8473-81441c124f74.jpg)

The graphs were calculated with all of the default values entered into the sidebar. The values in the graph do not change, except for the added day. This is due to the incorrect indexing error with the panda data frames. This becomes apparent when looking at the data in csv format. Here is what the new admissions data looks like using a text difference checker.

------------(With the change) ------------------------------------------- (Without the change)---------
![Capture](https://user-images.githubusercontent.com/61572112/78086954-75abd580-738d-11ea-85fa-8528f974cac0.JPG)

Now both the chart and the csv files display the proper number of days, and the csv files end with the correct day number.


***The first two commits did not fully solve the issue, the third and final commit does**