### PR TITLE
patch correct demorgan in Rate

### DIFF
--- a/src/penn_chime/parameters.py
+++ b/src/penn_chime/parameters.py
@@ -67,7 +67,7 @@ class Parameters:
         recovered: int = 0,
         region: Optional[Regions] = None,
     ):
-        self.current_hospitalized = StrictlyPositive(value=current_hospitalized)
+        self.current_hospitalized = Positive(value=current_hospitalized)
         self.relative_contact_rate = Rate(value=relative_contact_rate)
 
         Rate(value=hospitalized.rate), Rate(value=icu.rate), Rate(value=ventilated.rate)

--- a/src/penn_chime/validators/validators.py
+++ b/src/penn_chime/validators/validators.py
@@ -47,7 +47,7 @@ class Rate(Validator):
         pass
    
     def validate(self, value):
-        if 0 >= value or value >= 1:
+        if 0 > value or value > 1:
             raise ValueError(f"{value} needs to be a rate (i.e. in [0,1]).")
 
 class Date(Validator):


### PR DESCRIPTION
patched `Rate` validator, it was excluding 0 and 1 from the realm of possibility. 

In this PR, for example, market_share == 100% is now valid. It is not currently valid in prod. 