### PR TITLE
Fixes/cypress hardening

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -46,4 +46,13 @@ jobs:
         working-directory: e2e
         wait-on: 'http://localhost:8000'
         wait-on-timeout: 300
-
+    - uses: actions/upload-artifact@v1
+      if: failure()
+      with:
+        name: cypress-screenshots
+        path: e2e/cypress/screenshots
+    - uses: actions/upload-artifact@v1
+      if: always()
+      with:
+        name: cypress-videos
+        path: e2e/cypress/videos

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -41,7 +41,7 @@ jobs:
       run: |
         streamlit run src/app.py &
     - name: Cypress
-      uses: cypress-io/github-action@v1.23.2
+      uses: cypress-io/github-action@v1
       with:
         working-directory: e2e
         wait-on: 'http://localhost:8000'

--- a/e2e/cypress.json
+++ b/e2e/cypress.json
@@ -1,3 +1,5 @@
 {
-    "baseUrl": "http://localhost:8000"
+    "baseUrl": "http://localhost:8000",
+    "viewportWidth": 1200,
+    "viewportHeight": 660
 }

--- a/e2e/cypress/integration/tests/steppers.spec.js
+++ b/e2e/cypress/integration/tests/steppers.spec.js
@@ -8,12 +8,12 @@ context('Increment steppers', () => {
   it('Increment regional population', () => {
     cy.contains('Hospitalized Admissions peaks at 300');
 
-    cy.get('input.st-al').eq(0)
+    cy.get('input[type=number]').eq(0)
       .should('has.value', '3600000');
 
     cy.get('.step-up').eq(0).click();
 
-    cy.get('input.st-al').eq(0)
+    cy.get('input[type=number]').eq(0)
       .should('has.value', '3600001');
 
     cy.contains('Hospitalized Admissions peaks at 300');
@@ -22,12 +22,12 @@ context('Increment steppers', () => {
   it('Increment hospital market share', () => {
     cy.contains('Hospitalized Admissions peaks at 300');
 
-    cy.get('input.st-al').eq(1)
+    cy.get('input[type=number]').eq(1)
       .should('has.value', '15');
 
     cy.get('.step-up').eq(1).click();
 
-    cy.get('input.st-al').eq(1)
+    cy.get('input[type=number]').eq(1)
       .should('has.value', '15.1');
 
     cy.contains('Hospitalized Admissions peaks at 302');
@@ -36,12 +36,12 @@ context('Increment steppers', () => {
   it('Increment doubling time', () => {
     cy.contains('Hospitalized Admissions peaks at 300');
 
-    cy.get('input.st-al').eq(3)
+    cy.get('input[type=number]').eq(3)
       .should('has.value', '4');
 
     cy.get('.step-up').eq(3).click();
 
-    cy.get('input.st-al').eq(3)
+    cy.get('input[type=number]').eq(3)
       .should('has.value', '4.25');
 
     cy.contains('Hospitalized Admissions peaks at 272');


### PR DESCRIPTION
This fixes a few issues that lingered from the initial cypress setup:

- was pinned to a specific old release, install docs recommend broad pin to `v1`
- didn't include steps for uploading screenshots and videos for examining test results
- relied on a pretty arbitrary selector for the input elements that Streamlit seems to vary in random circumstances
- No fixed viewport size was configured for tests

Where nearly half my test runs were failing locally before, zero do now