### PR TITLE
Adapt Parameters and CLI to mostly automatically stay in sync

### DIFF
--- a/src/penn_chime/cli.py
+++ b/src/penn_chime/cli.py
@@ -8,7 +8,7 @@ from argparse import (
 from pandas import DataFrame
 
 from .constants import CHANGE_DATE
-from .parameters import Parameters, Disposition
+from .parameters import Parameters, Disposition, ACCEPTED_PARAMETERS
 from .models import SimSirModel as Model
 
 

--- a/src/penn_chime/cli.py
+++ b/src/penn_chime/cli.py
@@ -4,7 +4,6 @@ from argparse import (
     Action,
     ArgumentParser,
 )
-from datetime import datetime
 
 from pandas import DataFrame
 
@@ -21,8 +20,16 @@ class FromFile(Action):
             parser.parse_args(f.read().split(), namespace)
 
 
-def cast_date(string):
-    return datetime.strptime(string, '%Y-%m-%d').date()
+def declarative_validator(cast):
+    """Validator."""
+
+    def validate(string):
+        """Validate."""
+        if string == '' and cast != str:
+            return None
+        return cast(string)
+
+    return validate
 
 
 def validator(arg, cast, min_value, max_value, required=True):
@@ -49,31 +56,18 @@ def parse_args():
     parser = ArgumentParser(description=f"penn_chime: {CHANGE_DATE}")
     parser.add_argument("--file", type=open, action=FromFile)
 
+    for name, (params_validator, default, cast, help) in ACCEPTED_PARAMETERS.items():
+        if cast is None:
+            continue
+
+        parser.add_argument(
+            "--" + name.replace('_', '-'),
+            type=declarative_validator(cast),
+            default=default,
+            help=help
+        )
+
     for arg, cast, min_value, max_value, help, required in (
-        (
-            "--current-hospitalized",
-            int,
-            0,
-            None,
-            "Currently hospitalized COVID-19 patients (>= 0)",
-            True,
-        ),
-        (
-            "--date-first-hospitalized",
-            cast_date,
-            None,
-            None,
-            "Current date",
-            False,
-        ),
-        (
-            "--doubling-time",
-            float,
-            0.0,
-            None,
-            "Doubling time before social distancing (days)",
-            True,
-        ),
         ("--hospitalized-days", int, 0, None, "Average hospital length of stay (in days)", True),
         (
             "--hospitalized-rate",
@@ -85,25 +79,7 @@ def parse_args():
         ),
         ("--icu-days", int, 0, None, "Average days in ICU", True),
         ("--icu-rate", float, 0.0, 1.0, "ICU rate: 0.0 - 1.0", True),
-        (
-            "--market_share",
-            float,
-            0.00001,
-            1.0,
-            "Hospital market share (0.00001 - 1.0)",
-            True,
-        ),
-        ("--infectious-days", float, 0.0, None, "Infectious days", True),
-        ("--n-days", int, 0, None, "Number of days to project >= 0", True),
-        (
-            "--relative-contact-rate",
-            float,
-            0.0,
-            1.0,
-            "Social distancing reduction rate: 0.0 - 1.0",
-            True,
-        ),
-        ("--population", int, 1, None, "Regional population >= 1", True),
+
         ("--ventilated-days", int, 0, None, "Average days on ventilator", True),
         ("--ventilated-rate", float, 0.0, 1.0, "Ventilated Rate: 0.0 - 1.0", True),
     ):
@@ -119,19 +95,24 @@ def main():
     """Main."""
     a = parse_args()
 
-    p = Parameters(
-        current_hospitalized=a.current_hospitalized,
-        date_first_hospitalized=a.date_first_hospitalized,
-        doubling_time=a.doubling_time,
-        infectious_days=a.infectious_days,
-        market_share=a.market_share,
-        n_days=a.n_days,
-        relative_contact_rate=a.relative_contact_rate,
-        population=a.population,
+    del a.file
 
-        hospitalized=Disposition(a.hospitalized_rate, a.hospitalized_days),
-        icu=Disposition(a.icu_rate, a.icu_days),
-        ventilated=Disposition(a.ventilated_rate, a.ventilated_days),
+    hospitalized = Disposition(a.hospitalized_rate, a.hospitalized_days)
+    icu = Disposition(a.icu_rate, a.icu_days)
+    ventilated = Disposition(a.ventilated_rate, a.ventilated_days)
+
+    del a.hospitalized_days
+    del a.hospitalized_rate
+    del a.icu_days
+    del a.icu_rate
+    del a.ventilated_days
+    del a.ventilated_rate
+
+    p = Parameters(
+        hospitalized=hospitalized,
+        icu=icu,
+        ventilated=ventilated,
+        **vars(a)
     )
 
     m = Model(p)

--- a/src/penn_chime/parameters.py
+++ b/src/penn_chime/parameters.py
@@ -9,7 +9,7 @@ from datetime import date
 from typing import Optional
 
 from .validators import (
-    Positive, OptionalStrictlyPositive, StrictlyPositive, Rate, Date, OptionalDate
+    Positive, OptionalStrictlyPositive, StrictlyPositive, Rate, Date, OptionalDate, ValDisposition
     )
 
 # Parameters for each disposition (hospitalized, icu, ventilated)
@@ -69,9 +69,9 @@ class Parameters:
         region: Optional[Regions] = None,
     ):
         self.current_hospitalized = Positive(value=current_hospitalized)
-        Rate(value=hospitalized.rate), Rate(value=icu.rate), Rate(value=ventilated.rate)
-        StrictlyPositive(value=hospitalized.days), StrictlyPositive(value=icu.days),
-        StrictlyPositive(value=ventilated.days)
+        ValDisposition(value=hospitalized)
+        ValDisposition(value=icu)
+        ValDisposition(value=ventilated)
 
         self.hospitalized = hospitalized
         self.icu = icu

--- a/src/penn_chime/parameters.py
+++ b/src/penn_chime/parameters.py
@@ -5,7 +5,7 @@ constants.py `change_date``.
 """
 
 from collections import namedtuple
-from datetime import date
+from datetime import date, datetime
 from typing import Optional
 
 from .validators import (
@@ -45,24 +45,29 @@ class Regions:
         self.population = population
 
 
-ACCEPTED_PARAMETERS = {
-    "current_hospitalized": (Positive, None),
-    "current_date": (OptionalDate, None),
-    "date_first_hospitalized": (OptionalDate, None),
-    "doubling_time": (OptionalStrictlyPositive, None),
-    "relative_contact_rate": (Rate, None),
-    "mitigation_date": (OptionalDate, None),
-    "infectious_days": (StrictlyPositive, 14),
-    "market_share": (Rate, 1.0),
-    "max_y_axis": (OptionalStrictlyPositive, None),
-    "n_days": (StrictlyPositive, 100),
-    "recovered": (Positive, 0),
-    "population": (OptionalStrictlyPositive, None),
-    "region": (OptionalValue, None),
+def cast_date(string):
+    return datetime.strptime(string, '%Y-%m-%d').date()
 
-    "hospitalized": (ValDisposition, None),
-    "icu": (ValDisposition, None),
-    "ventilated": (ValDisposition, None),
+
+# Dictionary from parameter names to Tuples containing (validator, default value, cast function, help text)
+ACCEPTED_PARAMETERS = {
+    "current_hospitalized": (Positive, None, int, "Currently hospitalized COVID-19 patients (>= 0)"),
+    "current_date": (OptionalDate, None, cast_date, "Date on which the forecast should be based"),
+    "date_first_hospitalized": (OptionalDate, None, cast_date, "Date the first patient was hospitalized"),
+    "doubling_time": (OptionalStrictlyPositive, None, float, "Doubling time before social distancing (days)"),
+    "relative_contact_rate": (Rate, None, float, "Social distancing reduction rate: 0.0 - 1.0"),
+    "mitigation_date": (OptionalDate, None, cast_date, "Date on which social distancing measures too effect"),
+    "infectious_days": (StrictlyPositive, 14, int, "Infectious days"),
+    "market_share": (Rate, 1.0, float, "Hospital market share (0.00001 - 1.0)"),
+    "max_y_axis": (OptionalStrictlyPositive, None, int, None),
+    "n_days": (StrictlyPositive, 100, int, "Number of days to project >= 0"),
+    "recovered": (Positive, 0, int, "Number of patients already recovered (not yet implemented)"),
+    "population": (OptionalStrictlyPositive, None, int, "Regional population >= 1"),
+    "region": (OptionalValue, None, None, "No help available"),
+
+    "hospitalized": (ValDisposition, None, None, None),
+    "icu": (ValDisposition, None, None, None),
+    "ventilated": (ValDisposition, None, None, None),
 }
 
 
@@ -76,7 +81,7 @@ class Parameters:
                 raise ValueError(f"Unexpected parameter {key}")
             passed_and_default_parameters[key] = value
 
-        for key, (validator, default_value) in ACCEPTED_PARAMETERS.items():
+        for key, (validator, default_value, cast, help) in ACCEPTED_PARAMETERS.items():
             if key not in passed_and_default_parameters:
                 passed_and_default_parameters[key] = default_value
 

--- a/src/penn_chime/parameters.py
+++ b/src/penn_chime/parameters.py
@@ -85,7 +85,7 @@ class Parameters:
             try:
                 validator(value=value)
             except (TypeError, ValueError) as ve:
-                raise ValueError(f"For parameter {key}, with value {value}, validation returned error \"{ve}\"")
+                raise ValueError(f"For parameter '{key}', with value '{value}', validation returned error \"{ve}\"")
             setattr(self, key, value)
 
         if self.region is  None and self.population is None:

--- a/src/penn_chime/validators/__init__.py
+++ b/src/penn_chime/validators/__init__.py
@@ -1,8 +1,6 @@
 """the callable validator design pattern"""
 
-from .validators import Bounded, OptionalBounded, Rate, Date, OptionalDate
-
-EPSILON = 1.e-7
+from .validators import EPSILON, Bounded, OptionalBounded, Rate, Date, OptionalDate, ValDisposition
 
 OptionalStrictlyPositive = OptionalBounded(lower_bound=EPSILON)
 StrictlyPositive = Bounded(lower_bound=EPSILON)
@@ -10,5 +8,6 @@ Positive = Bounded(lower_bound=-EPSILON)
 Rate = Rate()  # type: ignore
 Date = Date()  # type: ignore
 OptionalDate = OptionalDate()  # type: ignore
+ValDisposition = ValDisposition()
 # # rolling a custom validator for doubling time in case DS wants to add upper bound
 # DoublingTime = OptionalBounded(lower_bound=0-EPSILON, upper_bound=None)

--- a/src/penn_chime/validators/__init__.py
+++ b/src/penn_chime/validators/__init__.py
@@ -1,7 +1,8 @@
 """the callable validator design pattern"""
 
-from .validators import EPSILON, Bounded, OptionalBounded, Rate, Date, OptionalDate, ValDisposition
+from .validators import EPSILON, OptionalValue, Bounded, OptionalBounded, Rate, Date, OptionalDate, ValDisposition
 
+OptionalValue = OptionalValue()
 OptionalStrictlyPositive = OptionalBounded(lower_bound=EPSILON)
 StrictlyPositive = Bounded(lower_bound=EPSILON)
 Positive = Bounded(lower_bound=-EPSILON)

--- a/src/penn_chime/validators/validators.py
+++ b/src/penn_chime/validators/validators.py
@@ -7,6 +7,14 @@ from .base import Validator
 
 EPSILON = 1.e-7
 
+class OptionalValue(Validator):
+    """Any value at all"""
+    def __init__(self) -> None:
+        pass
+
+    def validate(self, value):
+        pass
+
 class Bounded(Validator):
     """A bounded number."""
     def __init__(

--- a/src/penn_chime/validators/validators.py
+++ b/src/penn_chime/validators/validators.py
@@ -5,6 +5,7 @@ from datetime import date, datetime
 
 from .base import Validator
 
+EPSILON = 1.e-7
 
 class Bounded(Validator):
     """A bounded number."""
@@ -67,3 +68,11 @@ class OptionalDate(Date):
         if value is None:
             return None
         super().validate(value)
+
+class ValDisposition(Validator):
+    def __init__(self) -> None:
+        pass
+
+    def validate(self, value):
+        Bounded(lower_bound=EPSILON)(value=value.days)
+        Rate()(value=value.rate)

--- a/src/penn_chime/validators/validators.py
+++ b/src/penn_chime/validators/validators.py
@@ -32,6 +32,8 @@ class Bounded(Validator):
 
     def validate(self, value):
         """This method implicitly validates isinstance(value, (float, int)) because it will throw a TypeError on comparison"""
+        if value is None:
+            raise ValueError(f"This parameter must be set")
         if (self.upper_bound is not None and value > self.upper_bound) \
            or (self.lower_bound is not None and value < self.lower_bound):
             raise ValueError(f"{value} needs to be {self.message[(self.lower_bound, self.upper_bound)]}.")
@@ -56,6 +58,8 @@ class Rate(Validator):
         pass
    
     def validate(self, value):
+        if value is None:
+            raise ValueError(f"This parameter must be set")
         if 0 > value or value > 1:
             raise ValueError(f"{value} needs to be a rate (i.e. in [0,1]).")
 
@@ -65,6 +69,8 @@ class Date(Validator):
         pass
 
     def validate(self, value):
+        if value is None:
+            raise ValueError(f"This parameter must be set")
         if not isinstance(value, (date, datetime)):
             raise (ValueError(f"{value} must be a date or datetime object."))
 
@@ -82,5 +88,7 @@ class ValDisposition(Validator):
         pass
 
     def validate(self, value):
+        if value is None:
+            raise ValueError(f"This parameter must be set")
         Bounded(lower_bound=EPSILON)(value=value.days)
         Rate()(value=value.rate)


### PR DESCRIPTION
Rather than hard-coding the available parameters in the CLI source, have it read the relevant set out of Parameters directly.

Fixes: #491