### PR TITLE
Added parameters to the run command in README.md

### DIFF
--- a/src/chime_dash/README.md
+++ b/src/chime_dash/README.md
@@ -119,7 +119,7 @@ Install the chime base module
 ```
 and run
 ```bash
-> python src/dash_app.py
+> PARAMETERS=defaults/webapp.cfg python src/dash_app.py
 ```
 in the project root and visit the local url.
 


### PR DESCRIPTION
<!-- Please read the contributing guidelines before submitting: https://codeforphilly.github.io/chime/CONTRIBUTING.html -->

<!--
- If this PR affects devops or model, start your PR title with `[DevOps]` or `[Model]`
- Update the user or developer documentation, if affected.
-->

### Link to issue
- Not Linked to Any Issue

### Changelog entry
- Run command for the dash app in cli is out of date; it no longer works. Adding the default parameters in the command fixes this. 

![image](https://user-images.githubusercontent.com/61572112/79014295-9831b180-7b38-11ea-9b3d-285868c20a08.png)

- Running it with the default parameters fixes this error.

![image](https://user-images.githubusercontent.com/61572112/79014422-db8c2000-7b38-11ea-8a17-bbcbbd8fb8b7.png)


### Additional info
- @quinn-dougherty mentioned this in the chime-app channel, but the README.md file was not updated.