### PR TITLE
Developer Guide: Updated ToC sequence to match content in page

### DIFF
--- a/docs/contributing/app-dev.md
+++ b/docs/contributing/app-dev.md
@@ -3,8 +3,8 @@
 ## Table of Contents
 
 - [Developer Requirements](#developer-requirements)
-- [Project Layout](#project-layout)
 - [Running CHIME Locally](#running-chime-locally)
+- [Project Layout](#project-layout)
 - [Testing](#testing)
 - [Validating CHIME](#validating-chime)
 


### PR DESCRIPTION
- Content in the Developer Guide page lists 'Running Chime locally' section before 'Project Layout' section
- Updated the ToC to reflect this