### PR TITLE
[App] Add st_app.py to the Docker file.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ COPY setup.py .
 COPY .streamlit .streamlit
 COPY defaults defaults
 COPY src src
+COPY st_app.py st_app.py
 RUN pip install -q .
 
 CMD ["streamlit", "run", "st_app.py"]


### PR DESCRIPTION
### Changelog entry
Add `st_app.py` to the Dockerfile so the getting started process `script/server` works. 

### Additional info
The getting started process is broken because the dev is expected to run the `script/server` script and have everything work. Upon looking at the Dockerfile the app is in a constant restart cycle and therefore can't start.

Looking at the logs the st_app.py file is not being copied to the workdir in the container and therefore the container fails to start.
