### PR TITLE
Fix heroku deploy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM python:3.7.7-slim-buster
 ENV PARAMETERS=./defaults/webapp.cfg
+ENV PORT=8000
 WORKDIR /app
 COPY README.md .
 COPY setup.cfg .
@@ -10,6 +11,4 @@ COPY defaults defaults
 COPY src src
 COPY st_app.py st_app.py
 RUN pip install -q .
-
-CMD ["streamlit", "run", "st_app.py"]
-
+CMD STREAMLIT_SERVER_PORT=$PORT streamlit run st_app.py

--- a/heroku.yml
+++ b/heroku.yml
@@ -1,5 +1,5 @@
 build:
   docker:
-    web: Dockerfile.dash
+    web: Dockerfile
   config: 
     PORT: ${PORT}


### PR DESCRIPTION
This PR fixes the broken heroku build. To test it you will need a heroku account and you will need to run 
```bash
heroku stack:set container -a <appname>
heroku git:remote -a <appname>
git push heroku fix_heroku_deploy:master
```

This will set heroku to use docker and will deploy it to your heroku account.

For demonstration purposes this branch has been deployed to https://pennchime.herokuapp.com/

---

## <center>Pull Request Checklist</center>

### <center>For Reviewer</center>

- [x] Submitted under the correct tag
- [x] Runs without error or warning
- [x] Documentation  revised / included
- [ ] Unit tests included
- [ ] Issues referenced
- [x] Does not create new bugs / issues
