### PR TITLE
[DevOps] Allow downgraded setuptools for heroku

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 __version__ = "1.1.4"  # update VERSION in constants.py
 __author__ = "Predictive Healthcare @ Penn Medicine"
 
-from setuptools import setup, find_namespace_packages
+from setuptools import setup, find_packages
 
 
 setup(
@@ -19,7 +19,7 @@ setup(
         "Documentation": "https://codeforphilly.github.io/chime/",
     },
     package_dir={'': 'src'},
-    packages=find_namespace_packages(where='src', exclude=('tests')),
+    packages=find_packages(where='src', exclude=('tests')),
     install_requires=[
         "altair",
         "black",


### PR DESCRIPTION
# Link to issue

- May fix #576 

# Changelog entry

- Allow old versions of setuptools for heroku

---

## <center>Pull Request Checklist</center>

### <center>For Reviewer</center>

- [ ] Submitted under the correct tag
- [ ] Runs without error or warning
- [ ] Documentation  revised / included
- [ ] Unit tests included
- [ ] Issues referenced
- [ ] Does not create new bugs / issues
